### PR TITLE
Ignore blank lines and lines starting with '#'

### DIFF
--- a/Mac Apps Scripts/README.md
+++ b/Mac Apps Scripts/README.md
@@ -32,12 +32,13 @@ info@RCdiy.ca
 - A sound file is generated and placed in the current working directory.
 
 ## OpenTX Sound Mapping Files
-OpenTX uses a simple semicolon separated file to map the directory path, file name and spoken phrase.
+OpenTX uses a simple semicolon separated file to map the directory path, file name and spoken phrase. Blank lines and lines starting with '#' are ignored.
 - directory_path;name.wav;phrase
 
 ### Examples
  SOUNDS/en/SYSTEM;0000.wav;0
 
+ # This is a comment line
  SOUNDS/en;fm-thmr.wav;flight mode!, thermal right
 
 ### Sound File Names

--- a/Mac Apps Scripts/SoundPackGenerator.sh
+++ b/Mac Apps Scripts/SoundPackGenerator.sh
@@ -80,6 +80,8 @@ else
     echo "Voice being used $Voice"
   fi
 
+  # awk -F ";" -v Voice=$Voice '{
+  # skip blank lines, starting with #
   awk -F ";" -v Voice=$Voice 'NF && $1!~/^#/ {
     FileOut=$1"/"$2
     Phrase=$3

--- a/Mac Apps Scripts/SoundPackGenerator.sh
+++ b/Mac Apps Scripts/SoundPackGenerator.sh
@@ -80,7 +80,7 @@ else
     echo "Voice being used $Voice"
   fi
 
-  awk -F ";" -v Voice=$Voice '{
+  awk -F ";" -v Voice=$Voice 'NF && $1!~/^#/ {
     FileOut=$1"/"$2
     Phrase=$3
 

--- a/Mac Apps Scripts/SoundPackGenerator.sh
+++ b/Mac Apps Scripts/SoundPackGenerator.sh
@@ -91,6 +91,8 @@ else
       system("mkdir -p " $1)
     }
 
+    # system("say -v " Voice " -o " FileOut " --data-format=LEI16@32000  " "\""Phrase"\"")
+    # specified output because on some systems it had problems
     system("say --file-format=WAVE --data-format=LEI16@32000 --channels=1 -v " Voice " -o " FileOut " " "\""Phrase"\"")
     print FileOut
   }' $FileIn

--- a/Mac Apps Scripts/SoundPackGenerator.sh
+++ b/Mac Apps Scripts/SoundPackGenerator.sh
@@ -89,7 +89,7 @@ else
       system("mkdir -p " $1)
     }
 
-    system("say -v " Voice " -o " FileOut " --data-format=LEI16@32000  " "\""Phrase"\"")
+    system("say --file-format=WAVE --data-format=LEI16@32000 --channels=1 -v " Voice " -o " FileOut " " "\""Phrase"\"")
     print FileOut
   }' $FileIn
 


### PR DESCRIPTION
Sorry for the two unrelated fixes in one PR, I didn't create a PR branch for these:

1) In CSV input file, ignore blank lines and lines starting with '#'. When adding a lot of user-defined sounds, it is convenient to break up the file into sections using blank lines and add comments. It also makes it easy to comment out the "hello.wav" sound, to avoid a loud volume OpenTX startup.

2) Be more specific with output format in 'say' command. I had a problem with the Allison voice producing wave files that Companion and VLC would play, but my TX would not. Using the "file" command and comparing against existing wav files on my SD card for other languages, there were some differences, so I added the --file-format, cmdline param. It shouldn't be needed, but it is for me.